### PR TITLE
Port removed from server address

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -68,7 +68,7 @@ const IndexPage = () => {
                   1.16.4. Trage unter Multiplayer die folgende Adresse für
                   unseren Server ein:
                 </p>
-                <span className="address">skycave.de:25565</span>
+                <span className="address">skycave.de</span>
               </div>
             </div>
             <div className="column-centered col-3 padding-col">


### PR DESCRIPTION
25565 is the Minecraft default port and does not need to be entered in Minecraft. At the same time, this minimal change improves the display of the website on mobile devices (example iPhone 12), so that copying the address is possible again.